### PR TITLE
Fix animation height problem by adding fontSize value

### DIFF
--- a/lib/src/jumping_dots.dart
+++ b/lib/src/jumping_dots.dart
@@ -16,7 +16,7 @@ class _JumpingDot extends AnimatedWidget {
   Widget build(BuildContext context) {
     final Animation<double> animation = listenable;
     return Container(
-      height: animation.value,
+      height: animation.value + fontSize,
       child: Text(
         '.',
         style: TextStyle(color: color, fontSize: fontSize),


### PR DESCRIPTION
I had the issue, that the jumping dots were not visible anymore.
This solved the issue and i think it's a bug since 0.1.1 or maybe earlier.